### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Deploy documentation to nsls-ii.github.io
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501  # v3.7.3
+        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
         with:
           deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
           publish_branch: master

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,6 +32,8 @@ jobs:
           echo "DOCKER_BINARY=${DOCKER_BINARY}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }} with conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v1
+        uses: ts-graphviz/setup-graphviz@c001ccfb5aff62e28bda6a6c39b59a7e061be5b9 # v1
 
       - name: Set env vars
         run: |
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }} with conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2
         with:
           activate-environment: ${{ env.REPOSITORY_NAME }}-py${{ matrix.python-version }}
           auto-update-conda: true


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
